### PR TITLE
Fixed a typo?

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = async function(options) {
     return runTaskOnAllSites();
   }
 
-  if (argv._.length) {
+  if (argv.length) {
     throw new Error('To run a command line task you must specify either --all-sites or --site=hostname-or-id. To run a task for the dashboard site specify --site=dashboard');
   }
 


### PR DESCRIPTION
`node app` returned:

```
TypeError: Cannot read property 'length' of undefined
   at module.exports (/Users/bobclewell/Code/kimpton/node_modules/apostrophe-multisite/index.js:96:14) 
```

But with this change node app worked. So this fixed it? Seems likely.