### PR TITLE
SC-561: ability to set the admin password of a site via the dashboard

### DIFF
--- a/index.js
+++ b/index.js
@@ -622,6 +622,12 @@ module.exports = async function(options) {
                     label: 'Production Base URL',
                     help: 'like https://myproject.com',
                     type: 'url'
+                  },
+                  {
+                    name: 'adminPassword',
+                    label: 'Admin Password',
+                    type: 'password',
+                    help: 'Set password for the "admin" user of the new site. For pre-existing sites, leave blank for no change.'
                   }
                 ].concat(options.addFields || []);
 
@@ -635,6 +641,11 @@ module.exports = async function(options) {
                       'stagingBaseUrl',
                       'prodBaseUrl'
                     ]
+                  },
+                  {
+                    name: 'password',
+                    label: 'Password',
+                    fields: [ 'adminPassword' ]
                   }
                 ].concat(options.arrangeFields || []);
               },

--- a/lib/sites-base.js
+++ b/lib/sites-base.js
@@ -2,10 +2,22 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 
 module.exports = function(self, options) {
+
   self.beforeSave = function(req, doc, options, callback) {
+    if ((!doc._id) && (!doc.copyOfId)) {
+      if (!doc.adminPassword) {
+        self.apos.notify(req, 'You must fill out the admin password field when creating a new site.', { type: 'error' });
+        return callback('adminPassword.required');
+      }
+    }
+    // Don't let an admin password wind up in the db in cleartext
+    req.newAdminPassword = doc.adminPassword;
+    delete doc.adminPassword;
+
     doc.hostnames = _.map(doc.hostnamesArray || [], function(value) {
       return value.hostname.toLowerCase().trim();
     });
+
     return callback(null);
   };
 
@@ -24,14 +36,14 @@ module.exports = function(self, options) {
 
     async function body() {
       try {
-        await afterInsert(req, piece, options);
+        await copyContent(req, piece, options);
       } catch (e) {
         return callback(e);
       }
       return callback(null);
     }
 
-    async function afterInsert(req, piece, options) {
+    async function copyContent(req, piece, options) {
 
       if (!piece.copyOfId) {
         return;
@@ -136,6 +148,50 @@ module.exports = function(self, options) {
       // Trusts the extension because it was already in uploadfs. -Tom
       function getTempPath(file) {
         return to.attachments.uploadfs.getTempPath() + '/' + require('path') + self.apos.utils.generateId() + require('path').extname(file);
+      }
+    }
+  };
+
+  self.afterSave = async function(req, piece, options, callback) {
+
+    try {
+      if (req.newAdminPassword) {
+        await setAdminUser(req.newAdminPassword, piece, options);
+      }
+      return callback(null);
+    } catch (e) {
+      return callback(e);
+    }
+
+    async function setAdminUser(password, piece, options) {
+      const apos = await self.apos.options.multisite.getSiteApos(piece._id);
+      const req = apos.tasks.getReq();
+      const admin = await apos.users.find(req, { username: 'admin' }).toObject();
+      if (admin) {
+        admin.password = password;
+        console.log(admin);
+        return apos.users.update(req, admin);
+      } else {
+        const user = {
+          username: 'admin',
+          firstName: 'Admin',
+          lastName: 'User',
+          title: 'admin',
+          password
+        };
+        const group = await apos.groups.find(req, {
+          permissions: {
+            $in: [ 'admin' ]
+          }
+        }).toObject();
+        if (!group) {
+          group = await apos.groups.insert(req, {
+            title: 'admin',
+            permissions: [ 'admin' ]
+          });
+        }
+        user.groupIds = [ group._id ];
+        return apos.users.insert(apos.tasks.getReq(), user);
       }
     }
   };


### PR DESCRIPTION
KNOWN ISSUE: currently if you try to skip this field while creating a brand new site, you do get stopped, but you get two error messages, which is not ideal. Fixing this is tricky because we would have to either (a) allow apostrophe-multisite to push some initial frontend assets for site-base, which could get quite complicated, or (b) fix it so editor-modal can accept a full error message from the server without the need for any custom frontend code. Either is too much right now, but worth pursuing later.