### PR TITLE
Option to shut down automatically after a certain number of requests, to pragmatically address resource leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,8 @@ The `ENV` environment variable determines which environment will be used. If it 
 
 If you suspect your application is slowly leaking memory, HTTP sockets or some other resource that eventually renders it nonresponsive, you can set the `maxRequestsBeforeShutdown` option. The application will automatically exit after that number of requests. By default, this mechanism calls `process.exit(0)`. You can change this behavior by passing a custom `exit` function to `apostrophe-multisite` as an option.
 
+`10000` is a reasonable value for this option.
+
 Of course this assumes you are using `pm2`, `forever` or another mechanism to restart the application when it exits, and that you are also running at least one other process concurrently, so that they can cover for each other during restarts.
 
 To avoid 502 Bad Gateway errors when all of the processes stop at the same time, for instance due to round robin scheduling that delivers equal numbers of requests to them, a random number of additional requests between 0 and 1000 are accepted per process. This can be adjusted via the `additionalRequestsBeforeShutdown` option; set to 0 for no random factor at all.

--- a/README.md
+++ b/README.md
@@ -368,11 +368,11 @@ The `ENV` environment variable determines which environment will be used. If it 
 
 ## Resource leak mitigation
 
-If you suspect your application is slowly leaking memory, HTTP sockets or some other resource that eventually renders it nonresponsive, you can set the `maxRequestsBeforeShutdown` option. The application will automatically exit after that number of requests.
+If you suspect your application is slowly leaking memory, HTTP sockets or some other resource that eventually renders it nonresponsive, you can set the `maxRequestsBeforeShutdown` option. The application will automatically exit after that number of requests. By default, this mechanism calls `process.exit(0)`. You can change this behavior by passing a custom `exit` function to `apostrophe-multisite` as an option.
 
-Of course this assumes you are using `pm2`, `forever` or another mechanism to restart it when it exits, and that you are also running at least one other process concurrently, so that they can cover for each other during restarts.
+Of course this assumes you are using `pm2`, `forever` or another mechanism to restart the application when it exits, and that you are also running at least one other process concurrently, so that they can cover for each other during restarts.
 
-To avoid problems when all of the processes stop at the same time, for instance due to round robin scheduling that delivers equal numbers of requests to them, a random number of additional requests between 0 and 1000 are accepted per process. This can be adjusted via the `additionalRequestsBeforeShutdown` option; set to 0 for no random factor at all.
+To avoid 502 Bad Gateway errors when all of the processes stop at the same time, for instance due to round robin scheduling that delivers equal numbers of requests to them, a random number of additional requests between 0 and 1000 are accepted per process. This can be adjusted via the `additionalRequestsBeforeShutdown` option; set to 0 for no random factor at all.
 
 ## Project contribution
 

--- a/README.md
+++ b/README.md
@@ -366,6 +366,14 @@ You can create your own environment names by adding url fields to your `sites` p
 
 The `ENV` environment variable determines which environment will be used. If it is `prod` for example, the url used will be the one defined in the schema or in the sites configuration for `prod`.
 
+## Resource leak mitigation
+
+If you suspect your application is slowly leaking memory, HTTP sockets or some other resource that eventually renders it nonresponsive, you can set the `maxRequestsBeforeShutdown` option. The application will automatically exit after that number of requests.
+
+Of course this assumes you are using `pm2`, `forever` or another mechanism to restart it when it exits, and that you are also running at least one other process concurrently, so that they can cover for each other during restarts.
+
+To avoid problems when all of the processes stop at the same time, for instance due to round robin scheduling that delivers equal numbers of requests to them, a random number of additional requests between 0 and 1000 are accepted per process. This can be adjusted via the `additionalRequestsBeforeShutdown` option; set to 0 for no random factor at all.
+
 ## Project contribution
 
 ### Run tests

--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ module.exports = async function(options) {
     // that end politely without exiting the process on their own
     return runTaskOnAllSites({
       withoutForking: argv['without-forking'],
-      concurrency: argv['concurrency'] ? parseInt(argv['concurrency']) : 1
+      concurrency: argv.concurrency ? parseInt(argv.concurrency) : 1
     });
   }
 
@@ -242,7 +242,7 @@ module.exports = async function(options) {
     });
   }
 
-  self.server = server
+  self.server = server;
 
   return self;
 
@@ -262,7 +262,7 @@ module.exports = async function(options) {
 
   function dashboardMiddleware(req, res, next) {
     let site = req.get('Host');
-    const matches = site.match(/^([^\:]+)/);
+    const matches = site.match(/^([^:]+)/);
     if (!matches) {
       return next();
     }
@@ -275,7 +275,7 @@ module.exports = async function(options) {
 
   async function sitesMiddleware(req, res, next) {
     let site = req.get('Host');
-    const matches = (site || '').match(/^([^\:]+)/);
+    const matches = (site || '').match(/^([^:]+)/);
     if (!matches) {
       return next();
     }
@@ -293,7 +293,11 @@ module.exports = async function(options) {
     // direct all traffic for .multi test hostnames through
     // localhost:3000. However, this makes `req.url` an absolute
     // URL, which Apostrophe does not expect. Remove the host
-    req.url = require('url').parse(req.url).path;
+
+    const matches = req.url.match(/^\w+:\/\/[^/]*(\/.*)$/);
+    if (matches) {
+      req.url = matches[1];
+    }
     return next();
   }
 
@@ -324,7 +328,7 @@ module.exports = async function(options) {
     const logLevels = (process.env.LOG_LEVEL || (process.env.VERBOSE ? 'info,debug,warn,error' : defaultLogLevels)).split(/,\s*/);
     if (logLevels.includes(level)) {
       if ((level === 'warn') || (level === 'error')) {
-        if (argv['site']) {
+        if (argv.site) {
           console.error(msg); // eslint-disable-line no-console
         } else {
           // Trim the message because added blank lines do not read well
@@ -332,7 +336,7 @@ module.exports = async function(options) {
           console.error(name + ': ' + msg.trim()); // eslint-disable-line no-console
         }
       } else {
-        if (argv['site']) {
+        if (argv.site) {
           console.log(msg); // eslint-disable-line no-console
         } else {
           // Trim the message because added blank lines do not read well
@@ -848,7 +852,6 @@ module.exports = async function(options) {
     async function runOne(site) {
       log(site, 'info', `running task ${argv._[0]}`);
       const apos = await self.getSiteApos(site, { argv: { _: [] } });
-      const task = apos.tasks.find(argv._[0]);
       await apos.tasks.invoke(argv._[0], argv._.slice(1), argv);
       await Promise.promisify(apos.destroy)();
     }

--- a/lib/sites-base.js
+++ b/lib/sites-base.js
@@ -30,7 +30,7 @@ module.exports = {
           label: 'URLs',
           fields: [
             'shortName',
-            'prodHostname',
+            'prodHostname'
           ]
         }
       ];
@@ -121,7 +121,7 @@ module.exports = {
           return callback(null);
         }
         // Most common mistakes: protocol in the shortname, domain name in the shortname
-        if (shortName.match(/\:|\.|\s/)) {
+        if (shortName.match(/:|\.|\s/)) {
           self.apos.notify(req, 'The short name of the site must not contain dots, a protocol or spaces. It is a short name like "nifty" (without quotes) <F2>and will be used as a "working name" for a temporary subdomain for your site until it is launched.', { type: 'error' });
           return callback('invalid');
         }
@@ -364,7 +364,7 @@ module.exports = {
         }
         if (!site.shortName) {
           if (!site.trash) {
-            console.log('Warning: had to set the shortName to ' + site.slug + ' for ' + site.title + ' due to a lack of candidates in the legacy BaseUrl settings.', site.devBaseUrl, site.stagingBaseUrl, site.prodBaseUrl);
+            self.apos.utils.warn('Warning: had to set the shortName to ' + site.slug + ' for ' + site.title + ' due to a lack of candidates in the legacy BaseUrl settings.', site.devBaseUrl, site.stagingBaseUrl, site.prodBaseUrl);
             site.shortName = site.slug;
           }
         }
@@ -411,7 +411,7 @@ module.exports = {
         if (site.prodBaseUrl.match(/^https?:/)) {
           return;
         }
-        console.log('adding protocol to prodBaseUrl for ', site._id + ': ' + site.prodHostname);
+        self.apos.utils.log('adding protocol to prodBaseUrl for ', site._id + ': ' + site.prodHostname);
         return self.apos.docs.db.update({
           _id: site._id
         }, {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "boring": "^0.1.0",
     "emulate-mongo-2-driver": "^1.0.2",
     "express": "^4.16.3",
+    "http-terminator": "^2.0.0",
     "lodash": "^4.17.5",
     "mkdirp": "^0.5.1",
     "resolve": "^1.14.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint --fix .",
-    "test": "nyc mocha --timeout=10000 --exit",
+    "test": "eslint . && nyc mocha --timeout=10000 --exit",
     "test:cover": "nyc --reporter=html npm test && open-cli ./coverage/index.html",
     "test:watch": "mocha --timeout=10000 --watch"
   },

--- a/test/app.js
+++ b/test/app.js
@@ -22,5 +22,6 @@ module.exports = async function(options = {}) {
     mongodbUrl: options.mongodbUrl || 'mongodb://localhost:27017',
     maxRequestsBeforeShutdown: options.maxRequestsBeforeShutdown,
     additionalRequestsBeforeShutdown: options.additionalRequestsBeforeShutdown,
+    exit: options.exit
   });
 };

--- a/test/app.js
+++ b/test/app.js
@@ -19,6 +19,7 @@ module.exports = async function(options = {}) {
     port: options.port || 3000,
     dashboardHostname: 'dashboard.test',
     shortNamePrefix: options.shortNamePrefix || 'test-multi-',
-    mongodbUrl: options.mongodbUrl || 'mongodb://localhost:27017'
+    mongodbUrl: options.mongodbUrl || 'mongodb://localhost:27017',
+    maxRequestsBeforeShutdown: options.maxRequestsBeforeShutdown
   });
 };

--- a/test/app.js
+++ b/test/app.js
@@ -20,6 +20,7 @@ module.exports = async function(options = {}) {
     dashboardHostname: 'dashboard.test',
     shortNamePrefix: options.shortNamePrefix || 'test-multi-',
     mongodbUrl: options.mongodbUrl || 'mongodb://localhost:27017',
-    maxRequestsBeforeShutdown: options.maxRequestsBeforeShutdown
+    maxRequestsBeforeShutdown: options.maxRequestsBeforeShutdown,
+    additionalRequestsBeforeShutdown: options.additionalRequestsBeforeShutdown,
   });
 };

--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,6 @@ const { expect } = require('chai');
 const rp = require('request-promise');
 const enableDestroy = require('server-destroy');
 const apostropheMultisite = require('./app.js');
-const Promise = require('bluebird');
 
 describe('Apostrophe-multisite', function() {
   describe('#dashboard', function() {

--- a/test/max-requests.js
+++ b/test/max-requests.js
@@ -7,7 +7,7 @@ const apostropheMultisite = require('./app.js');
 const Promise = require('bluebird');
 
 describe('Apostrophe-multisite', function() {
-  describe('#dashboard', function() {
+  describe('maxRequestsBeforeShutdown', function() {
     const port = 3000;
     const admin = 'admin';
     const url = 'site.test';
@@ -102,7 +102,7 @@ describe('Apostrophe-multisite', function() {
       let connected = 0;
       for (let i = 0; (i < 20); i++) {
         try {
-          const siteT = await rp(`http://site.test:${port}/`);
+          await rp(`http://site.test:${port}/`);
           connected++;
         } catch (e) {
           // Some of them should fail
@@ -113,6 +113,7 @@ describe('Apostrophe-multisite', function() {
       }
       expect(connected).to.be.below(16);
       expect(connected).to.be.above(9);
+      expect(exited).to.be.true; // eslint-disable-line no-unused-expressions
     });
   });
 });

--- a/test/max-requests.js
+++ b/test/max-requests.js
@@ -71,17 +71,6 @@ describe('Apostrophe-multisite', function() {
       multisite.server.destroy();
     });
 
-    it('starts the dashboard', async function() {
-      expect(multisite)
-        .to.be.an('object')
-        .that.has.any.keys('getSiteApos', 'dashboard', 'server');
-    });
-
-    it('creates a site', async function() {
-      expect(site).to.be.an('object');
-      expect(site.type).to.equal('site');
-    });
-
     it('inserts a site and can find it', async function() {
       const piece = await sites.insert(req, { ...site, ...newSite });
       expect(piece).to.be.an('object');


### PR DESCRIPTION
Enterprise clients have experienced occasional mystery slowdowns and outages in complex long-running node applications. We don't always know exactly why this happens in those particular cases.

We should find out, but in the general case, we will never eliminate every possible resource leak in a process that is both complex and long-lived.

So how do other people solve for this? There's precedent: the PHP interpreter is a complex beast, and even though each request is a "whole new world" to the PHP programmer, it's possible for the interpreter itself to leak resources due to a bug in its implementation. To resolve this, PHP offers an option to simply shut down and restart the PHP process after a certain maximum number of requests have been handled. As long as this number is high (10,000 is often suggested), we still get the performance benefits of a long-running process, while also cutting off any leaks before they reach serious levels that block the application.

apostrophe-multisite now has an equivalent option, `maxRequestsBeforeShutdown`. When this number of requests have been handled, plus a random additional number of requests between 0 and 1000 which can be adjusted via `additionalRequestsBeforeShutdown`, the process will give any pending requests a few seconds to complete gracefully, then simply exit. At which point pm2 (or forever, or whatever is in use) will restart it. Any leaks are cleaned up by the operating system when the process exits.

The random factor is there to prevent the entire site from issuing a 502 Bad Gateway Error if the proxy server is extremely fair in handing out requests and they all hit the 10,000 mark at the same moment. As long as they don't all restart at the same time, nginx will always be able to find a process that is currently accepting new connections.