### PR TITLE
Mongodb copy update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.10.0
+
+* Copying sites: starting with MongoDB server version 4.2, the `copydb` command is no longer supported, so we use a `mongodump | mongorestore` pipeline instead. For maximum backwards compatibility we don't do this unless we have to (MongoDB server version is 4.2 or greater). You should make sure up to date versions of these utilities are installed in the PATH for future compatibility.
+
 # 2.9.0
 
 * `destroy` method for the multisite object shuts down everything. Used for clean termination of mocha tests and verification that `apos.destroy` does its job too.

--- a/index.js
+++ b/index.js
@@ -146,6 +146,8 @@ module.exports = async function(options) {
     options.env = process.env.ENV;
   }
 
+  self.mongodbUrl = options.mongodbUrl;
+
   // All sites running under this process share a mongodb connection object
   const db = await mongo.MongoClient.connect(options.mongodbUrl, {
     useUnifiedTopology: true

--- a/lib/sites-base.js
+++ b/lib/sites-base.js
@@ -1,6 +1,10 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
 
+const exec = require('util').promisify(
+  require('child_process').exec
+);
+
 module.exports = {
   extend: 'apostrophe-pieces',
   instantiate: false,
@@ -278,15 +282,16 @@ module.exports = {
         }
 
         async function copyDatabase() {
+          // The copyDb command is gone in mongodb >= 4.2, use
+          // mongodump and mongorestore with --uri and --archive
+          // (works in 3.4.something and up)
           const shortNamePrefix = self.apos.shortName.replace(/dashboard$/, '');
-          // http://stackoverflow.com/questions/36403749/how-can-i-execute-db-copydatabase-through-nodejss-mongodb-native-driver
-          const command = {
-            copydb: 1,
-            fromdb: shortNamePrefix + piece.copyOfId,
-            todb: shortNamePrefix + piece._id
-          };
-          const admin = self.apos.db.admin();
-          return admin.command(command);
+          const baseUri = self.apos.options.multisite.mongodbUrl;
+          const fromDb = `${shortNamePrefix}${piece.copyOfId}`;
+          const toDb = `${shortNamePrefix}${piece._id}`;
+          const fromUri = `${baseUri}/${fromDb}`;
+          const toUri = `${baseUri}/${toDb}`;
+          return exec(`mongodump --uri=${fromUri} --archive | mongorestore --uri=${toUri} --nsFrom='${fromDb}.*' --nsTo='${toDb}.*' --archive --drop`);
         }
 
         async function getFrom() {

--- a/lib/sites-base.js
+++ b/lib/sites-base.js
@@ -289,7 +289,7 @@ module.exports = {
           const shortNamePrefix = self.apos.shortName.replace(/dashboard$/, '');
           // The copydb command requires no utilities that might not be installed,
           // so we use it until we hit a mongod version that does not support it at all
-          if (compareVersions(info.version, '5.0') < 0) {
+          if (compareVersions(info.version, '4.2') < 0) {
             const command = {
               copydb: 1,
               fromdb: shortNamePrefix + piece.copyOfId,

--- a/lib/sites-base.js
+++ b/lib/sites-base.js
@@ -1,5 +1,7 @@
 const Promise = require('bluebird');
 const _ = require('lodash');
+const shellQuote = require('shell-quote').quote;
+const compareVersions = require('compare-versions');
 
 const exec = require('util').promisify(
   require('child_process').exec
@@ -282,16 +284,31 @@ module.exports = {
         }
 
         async function copyDatabase() {
-          // The copyDb command is gone in mongodb >= 4.2, use
-          // mongodump and mongorestore with --uri and --archive
-          // (works in 3.4.something and up)
+          const admin = self.apos.db.admin();
+          const info = await admin.serverInfo();
           const shortNamePrefix = self.apos.shortName.replace(/dashboard$/, '');
-          const baseUri = self.apos.options.multisite.mongodbUrl;
-          const fromDb = `${shortNamePrefix}${piece.copyOfId}`;
-          const toDb = `${shortNamePrefix}${piece._id}`;
-          const fromUri = `${baseUri}/${fromDb}`;
-          const toUri = `${baseUri}/${toDb}`;
-          return exec(`mongodump --uri=${fromUri} --archive | mongorestore --uri=${toUri} --nsFrom='${fromDb}.*' --nsTo='${toDb}.*' --archive --drop`);
+          // The copydb command requires no utilities that might not be installed,
+          // so we use it until we hit a mongod version that does not support it at all
+          if (compareVersions(info.version, '5.0') < 0) {
+            const command = {
+              copydb: 1,
+              fromdb: shortNamePrefix + piece.copyOfId,
+              todb: shortNamePrefix + piece._id
+            };
+            return admin.command(command);
+          } else {
+            // The copyDb command is gone in mongodb >= 4.2, use
+            // mongodump and mongorestore with --uri and --archive
+            const fromDb = `${shortNamePrefix}${piece.copyOfId}`;
+            const toDb = `${shortNamePrefix}${piece._id}`;
+            const baseUri = new URL(self.apos.options.multisite.mongodbUrl);
+            baseUri.pathname = `/${fromDb}`;
+            const fromUri = baseUri.toString();
+            baseUri.pathname = `/${toDb}`;
+            const toUri = baseUri.toString();
+            const cmd = shellQuote([ 'mongodump', `--uri=${fromUri}`, '--archive' ]) + ' | ' + shellQuote([ 'mongorestore', `--uri=${toUri}`, `--nsFrom=${fromDb}.*`, `--nsTo=${toDb}.*`, '--archive', '--drop' ]);
+            return exec(cmd);
+          }
         }
 
         async function getFrom() {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "apostrophe": "^2.109.0",
     "chai": "^4.2.0",
     "del": "^5.1.0",
-    "eslint": "^6.8.0",
+    "eslint": "^7.1.0",
     "eslint-config-apostrophe": "^3.2.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-plugin-import": "^2.22.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-multisite",
-  "version": "2.9.0",
+  "version": "2.10.0",
   "description": "Multisite support for the Apostrophe CMS. Create & manage multiple sites with the same configuration and host them efficiently.",
   "main": "index.js",
   "scripts": {
@@ -31,6 +31,7 @@
   "dependencies": {
     "bluebird": "^3.5.1",
     "boring": "^0.1.0",
+    "compare-versions": "^3.6.0",
     "emulate-mongo-2-driver": "^1.2.3",
     "express": "^4.16.3",
     "http-terminator": "^2.0.3",


### PR DESCRIPTION
Because the `copydb` command was deprecated in mongodb >= 4.2.x, copying a site from the Assembly dashboard was not working. 