### PR TITLE
CDN support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.12.0 (2023-09-08)
+
+- Supports the `CDN` environment variable.
+
 ## 2.11.2 (2023-03-06)
 
 - Removes `apostrophe` as a peer dependency.

--- a/README.md
+++ b/README.md
@@ -414,6 +414,16 @@ You can create your own environment names by adding url fields to your `sites` p
 
 The `ENV` environment variable determines which environment will be used. If it is `prod` for example, the url used will be the one defined in the schema or in the sites configuration for `prod`.
 
+### Using a CDN
+
+If you are using a CDN such as Cloudfront or Cloudflare that automatically mirrors the contents of your S3 bucket or other uploadfs cloud storage, you can specify that CDN so that Apostrophe generates public URLs that reference it instead of pointing directly to the cloud storage:
+
+```
+CDN=https://myproject.my-cdn.com
+```
+
+Since the sites share a single cloud storage facility with a single URL, they also share a single CDN in front of that.
+
 ## Resource leak mitigation
 
 If you suspect your application is slowly leaking memory, HTTP sockets or some other resource that eventually renders it nonresponsive, you can set the `maxRequestsBeforeShutdown` option. The application will automatically exit after that number of requests. By default, this mechanism calls `process.exit(0)`. You can change this behavior by passing a custom `exit` function to `apostrophe-multisite` as an option.

--- a/index.js
+++ b/index.js
@@ -501,7 +501,15 @@ module.exports = async function(options) {
                 uploadsPath: getRootDir() + '/sites/public/uploads',
                 uploadsUrl: '/uploads',
                 tempPath: getRootDir() + '/sites/data/temp/' + site._id + '/uploadfs',
-                https: true
+                https: true,
+                ...(process.env.CDN
+                  ? {
+                    cdn: {
+                      enabled: true,
+                      url: process.env.CDN + '/' + site._id
+                    }
+                  }
+                  : {})
               }
             },
 
@@ -544,7 +552,16 @@ module.exports = async function(options) {
                     prefix: '/shared-assets',
                     uploadsPath: getRootDir() + '/sites/public/uploads',
                     uploadsUrl: '/uploads',
-                    tempPath: getRootDir() + '/sites/data/temp/shared-assets/uploadfs'
+                    tempPath: getRootDir() + '/sites/data/temp/shared-assets/uploadfs',
+                    ...(process.env.CDN
+                      ? {
+                        cdn: {
+                          enabled: true,
+                          // uploadfs does not apply the prefix to the CDN unless told to
+                          url: process.env.CDN + '/shared-assets'
+                        }
+                      }
+                      : {})
                   };
 
                   self.uploadfsSettings = {};
@@ -720,7 +737,15 @@ module.exports = async function(options) {
                 uploadsUrl: '/uploads',
                 tempPath: getRootDir() + '/data/temp/dashboard/uploadfs',
                 // Avoid mixed content warning
-                https: true
+                https: true,
+                ...(process.env.CDN
+                  ? {
+                    cdn: {
+                      enabled: true,
+                      url: process.env.CDN + '/dashboard'
+                    }
+                  }
+                  : {})
               }
             },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-multisite",
-  "version": "2.11.2",
+  "version": "2.12.0-alpha",
   "description": "Multisite support for the Apostrophe CMS. Create & manage multiple sites with the same configuration and host them efficiently.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
<!-- Please don't delete this template -->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## Summary

Support a CDN environment variable the same way we already do in A3 multisite.

uploadfs already supports it and A2 and A3 use the same version of uploadfs, so it's just about the plumbing of passing the right prefix option in different situations, which varies between A2 and A3 multisite. That took a minute to figure out.

## What are the specific steps to test this change?

I have tested it on Kimpton Staging, where https://thebettyatl.staging.kimpton.apos.dev/ now displays both assets and media as expected via cloudfront, using an alpha npm release based on this branch.

## What kind of change does this PR introduce?
*(Check at least one)*

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [X] Related documentation has been updated
- [ ] Related tests have been updated

If adding a new feature without an already open issue, it's best to open a **feature request issue** first and wait for approval before working on it.

**Other information:**
