### PR TITLE
autocomplete off, and fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## UNRELEASED
 
-- Verify that shortname is not already in use by another active site when saving a site.
+* Verify that shortname is not already in use by another active site when saving a site.
+* For safety, disable autocomplete of dashboard settings.
 
 ## 2.12.0 (2023-09-08)
 

--- a/index.js
+++ b/index.js
@@ -31,10 +31,10 @@ module.exports = async function(options) {
   // passed to initialize Apostrophe. This argument is typically
   // used to prevent `argv` from being reused.
 
-  self.getSiteApos = async function(siteOrId, options) {
+  self.getSiteApos = async function(siteOrId, options, { published } = {}) {
     let site = siteOrId;
     if ((typeof siteOrId) === 'string') {
-      site = await dashboard.docs.db.findOne({
+      const query = {
         type: 'site',
         _id: siteOrId,
         // For speed and because they can have their own users and permissions
@@ -44,9 +44,12 @@ module.exports = async function(options) {
         //
         // However, we do make sure the site is published and not in the trash,
         // to keep things intuitive for the superadmin.
-        trash: { $ne: true },
-        published: true
-      });
+        trash: { $ne: true }
+      };
+      if (published !== null) {
+        query.published = true;
+      }
+      site = await dashboard.docs.db.findOne(query);
     }
     return Promise.promisify(body)();
     function body(callback) {

--- a/lib/sites-base.js
+++ b/lib/sites-base.js
@@ -201,7 +201,7 @@ module.exports = {
       if ((!doc._id) && (!doc.copyOfId)) {
         if (!doc.adminPassword) {
           self.apos.notify(req, 'You must fill out the admin password field when creating a new site.', { type: 'error' });
-          return callback(new Error('adminPassword.required'));
+          return callback('adminPassword.required');
         }
       }
       // Don't let an admin password wind up in the db in cleartext
@@ -224,7 +224,7 @@ module.exports = {
         // Most common mistakes: protocol in the shortname, domain name in the shortname
         if (shortName.match(/:|\.|\s/)) {
           self.apos.notify(req, 'The short name of the site must not contain dots, a protocol or spaces. It is a short name like "nifty" (without quotes) <F2>and will be used as a "working name" for a temporary subdomain for your site until it is launched.', { type: 'error' });
-          return callback(new Error('invalid'));
+          return callback('invalid');
         }
 
         const existing = await self
@@ -239,7 +239,7 @@ module.exports = {
 
         if (existing) {
           self.apos.notify(req, 'That short name is already in use by another site.', { type: 'error' });
-          return callback(new Error('invalid'));
+          return callback('invalid');
         }
 
         doc.hostnames = [];
@@ -333,11 +333,11 @@ module.exports = {
         }
 
         async function getFrom() {
-          return self.apos.options.multisite.getSiteApos(piece.copyOfId);
+          return self.apos.options.multisite.getSiteApos(piece.copyOfId, { published: null });
         }
 
         async function getTo() {
-          return self.apos.options.multisite.getSiteApos(piece._id);
+          return self.apos.options.multisite.getSiteApos(piece._id, { published: null });
         }
 
         async function purgeTrash() {
@@ -438,7 +438,7 @@ module.exports = {
       }
 
       async function setAdminUser(password, piece, options) {
-        const apos = await self.apos.options.multisite.getSiteApos(piece._id);
+        const apos = await self.apos.options.multisite.getSiteApos(piece._id, { published: null });
         const req = apos.tasks.getReq();
         const admin = await apos.users.find(req, { username: 'admin' }).toObject();
         if (admin) {
@@ -605,6 +605,16 @@ module.exports = {
         }
       });
     });
+
+    const superComposeSchema = self.composeSchema;
+    self.composeSchema = () => {
+      superComposeSchema();
+      // Autocompleting fields in the dashboard causes a lot of pain
+      for (const field of self.schema) {
+        field.fieldAttributes = field.fieldAttributes || '';
+        field.fieldAttributes += ' autocomplete=off';
+      }
+    };
 
   },
 


### PR DESCRIPTION
* turn off autocomplete for all site dashboard fields.
* fix subtle bug introduced by the never-shipped fix to prevent duplicate shortnames.