### PR TITLE
release 2.12.2: revert 2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.12.2 (2024-04-29)
+
+* Removed the `autocomplete=off` change, which was redundant to code already existing in A2 core and also
+ineffective in current browsers, in favor of a new change in A2 core.
+
 ## 2.12.1 (2024-04-22)
 
 * Verify that shortname is not already in use by another active site when saving a site.

--- a/lib/sites-base.js
+++ b/lib/sites-base.js
@@ -606,16 +606,6 @@ module.exports = {
       });
     });
 
-    const superComposeSchema = self.composeSchema;
-    self.composeSchema = () => {
-      superComposeSchema();
-      // Autocompleting fields in the dashboard causes a lot of pain
-      for (const field of self.schema) {
-        field.fieldAttributes = field.fieldAttributes || '';
-        field.fieldAttributes += ' autocomplete=off';
-      }
-    };
-
   },
 
   afterConstruct: function(self) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-multisite",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "description": "Multisite support for the Apostrophe CMS. Create & manage multiple sites with the same configuration and host them efficiently.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Revert the main change in 2.12.1. We're solving this correctly now by using `new-password` in apostrophe core.