### PR TITLE
Fix assets module overrides for dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.12.4 (2025-01-23)
 
-* Fix an old bug that prevented `apostrophe-assets` project level code from working correctly.
+* Fix an old bug that prevented `apostrophe-assets` project level code from working correctly in the dashboard.
 
 ## 2.12.3 (2024-05-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.12.4 (2025-01-23)
+
+* Fix an old bug that prevented `apostrophe-assets` project level code from working correctly.
+
 ## 2.12.3 (2024-05-06)
 
 * Fix potential regression caused by 2.12.1: guarantee that a temporary site always has a unique `shortName`.

--- a/index.js
+++ b/index.js
@@ -701,16 +701,13 @@ module.exports = async function(options) {
 
           modules: {
 
-            'apostrophe-assets': {
+            'apostrophe-multisite-patch-assets': {
               construct: function(self, options) {
-                // Make it possible to disable the asset build so it doesn't
-                // take up time and change the asset generation if we're just
-                // running a task for another site, a situation in which we
-                // only need the dashboard in order to access the db containing
-                // that site
-                if (options.disabled) {
-                  self.afterInit = function() {};
-                  self.determineGenerationAndExtract = function() {};
+                if (self.apos.assets.options.disabled) {
+                  self.apos.assets.afterInit = function(callback) {
+                    return setImmediate(callback);
+                  };
+                  self.apos.assets.determineGenerationAndExtract = function() {};
                 }
               }
             },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apostrophe-multisite",
-  "version": "2.12.3",
+  "version": "2.12.4",
   "description": "Multisite support for the Apostrophe CMS. Create & manage multiple sites with the same configuration and host them efficiently.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using same improved technique already implemented for ordinary sites a long time ago. I did tests to confirm the asset build for dashboard doesn't try to run when you run a command line task for some other site (the purpose of the original code).